### PR TITLE
Bug 1242633 Set DISABLE_OPENSHIFT_MANAGED_SERVER_CONFIG as a cartridge env variable

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -35,8 +35,6 @@ pushd $OPENSHIFT_DV_DIR > /dev/null
   ln -s ${JBOSS_HOME}/modules
 popd 1> /dev/null
 
-# Disable Openshift management
-set_env_var DISABLE_OPENSHIFT_MANAGED_SERVER_CONFIG true ~/.env/user_vars
 
 # Set usernames, generate passwords and create env variables
 echo 'Generating username and password'
@@ -60,6 +58,8 @@ echo "$msuser_username" > $OPENSHIFT_DV_DIR/env/OPENSHIFT_DV_MSUSER_USERNAME
 echo "$msuser_password" > $OPENSHIFT_DV_DIR/env/OPENSHIFT_DV_MSUSER_PASSWORD
 echo "$msadmin_username" > $OPENSHIFT_DV_DIR/env/OPENSHIFT_DV_MSADMIN_USERNAME
 echo "$msadmin_password" > $OPENSHIFT_DV_DIR/env/OPENSHIFT_DV_MSADMIN_PASSWORD
+# Disable Openshift management
+echo "true" > $OPENSHIFT_DV_DIR/env/DISABLE_OPENSHIFT_MANAGED_SERVER_CONFIG
 
 # Create the teiid-security-users.properties file
 # ${OPENSHIFT_DV_DIR}/standalone/deployments


### PR DESCRIPTION
Previously, this variable was created as a user environment variable by placing it in the `~/.env/user_env/` directory. This caused the app to be unable to be cloned as described in [BZ#1242633](https://bugzilla.redhat.com/show_bug.cgi?id=1242633). 

This reverts a change made in aa4202d2d938608a474fc14176fccbb428168572

Users will still be able to overwrite this variable and set it to false by creating a user environment variable with the same name:

```
# rhc env-add DISABLE_OPENSHIFT_MANAGED_SERVER_CONFIG=false -a jdvtest1
Setting environment variable(s) ... done
# rhc app-stop jdvtest1; rhc app-start jdvtest1
```
